### PR TITLE
replace toast msg from login class to snackbar message

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="tabSettings">
+      <map>
+        <entry key="Firebase Crashlytics">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="PLACEHOLDER" />
+                  <option name="mobileSdkAppId" value="" />
+                  <option name="projectId" value="" />
+                  <option name="projectNumber" value="" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="THIRTY_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/app/src/androidTest/java/cc/wordview/app/ui/screens/login/LoginTest.kt
+++ b/app/src/androidTest/java/cc/wordview/app/ui/screens/login/LoginTest.kt
@@ -81,6 +81,7 @@ class LoginTest {
         composeTestRule.onNodeWithText("Log in")
             .assertIsEnabled()
             .performClick()
+        composeTestRule.onNodeWithText("Register failed!").assertDoesNotExist()
     }
 
     @Test
@@ -91,6 +92,8 @@ class LoginTest {
         composeTestRule.onNodeWithText("Log in")
             .assertIsEnabled()
             .performClick()
+
+        composeTestRule.onNodeWithText("This email address has not yet been registered").assertExists()
     }
 
     @Test
@@ -101,5 +104,7 @@ class LoginTest {
         composeTestRule.onNodeWithText("Log in")
             .assertIsEnabled()
             .performClick()
+
+        composeTestRule.onNodeWithText("Incorrect credentials").assertExists()
     }
 }

--- a/app/src/androidTest/java/cc/wordview/app/ui/screens/register/RegisterTest.kt
+++ b/app/src/androidTest/java/cc/wordview/app/ui/screens/register/RegisterTest.kt
@@ -117,6 +117,8 @@ class RegisterTest {
         composeTestRule.onNodeWithText("Create")
             .assertIsEnabled()
             .performClick()
+
+        composeTestRule.onNodeWithText("Register failed!").assertDoesNotExist()
     }
 
     @Test
@@ -129,5 +131,7 @@ class RegisterTest {
         composeTestRule.onNodeWithText("Create")
             .assertIsEnabled()
             .performClick()
+
+        composeTestRule.onNodeWithText("Register failed!").assertExists()
     }
 }

--- a/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Login.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Login.kt
@@ -50,7 +50,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import cc.wordview.app.ui.activities.auth.composables.FormValidation.Email
+import cc.wordview.app.ui.activities.auth.composables.FormValidation.*
 import cc.wordview.app.ui.activities.auth.viewmodel.login.LoginViewModel
 import cc.wordview.app.ui.activities.home.HomeActivity
 import cc.wordview.app.ui.components.AuthForm

--- a/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Login.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Login.kt
@@ -75,20 +75,17 @@ fun Login(
 
     val context = LocalContext.current
 
-    val snackBarHostState = remember { SnackbarHostState() } // ✅ This line is essential!
+    val snackBarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val message by viewModel.snackBarMessage.collectAsState(initial = "")
 
-
-    // 🔁 Collect events from ViewModel
-    if(message.isNotEmpty()) {
-        OneTimeEffect() {
+    LaunchedEffect(Unit) {
+        viewModel.snackBarMessage.collect {
             scope.launch {
                 snackBarHostState.showSnackbar(message)
             }
         }
     }
-
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Login.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Login.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,13 +51,14 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import cc.wordview.app.ui.activities.auth.composables.FormValidation.*
+import cc.wordview.app.ui.activities.auth.composables.FormValidation.Email
 import cc.wordview.app.ui.activities.auth.viewmodel.login.LoginViewModel
 import cc.wordview.app.ui.activities.home.HomeActivity
 import cc.wordview.app.ui.components.AuthForm
 import cc.wordview.app.ui.components.CircularProgressIndicator
 import cc.wordview.app.ui.components.FormTextField
 import cc.wordview.app.ui.components.Icon
+import cc.wordview.app.ui.components.OneTimeEffect
 import cc.wordview.app.ui.components.Space
 import kotlinx.coroutines.launch
 
@@ -75,16 +77,18 @@ fun Login(
 
     val snackBarHostState = remember { SnackbarHostState() } // ✅ This line is essential!
     val scope = rememberCoroutineScope()
+    val message by viewModel.snackBarMessage.collectAsState(initial = "")
+
 
     // 🔁 Collect events from ViewModel
-    LaunchedEffect(Unit) {
-        viewModel.snackBarMessage.collect { message ->
-            // ✅ You can use `scope.launch` here, but it's optional
+    if(message.isNotEmpty()) {
+        OneTimeEffect() {
             scope.launch {
                 snackBarHostState.showSnackbar(message)
             }
         }
     }
+
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Login.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Login.kt
@@ -28,12 +28,16 @@ import androidx.compose.material.icons.filled.Password
 import androidx.compose.material3.Button
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,15 +50,15 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import cc.wordview.app.ui.activities.auth.composables.FormValidation.*
+import cc.wordview.app.ui.activities.auth.composables.FormValidation.Email
 import cc.wordview.app.ui.activities.auth.viewmodel.login.LoginViewModel
 import cc.wordview.app.ui.activities.home.HomeActivity
-import cc.wordview.app.ui.activities.player.PlayerActivity
 import cc.wordview.app.ui.components.AuthForm
 import cc.wordview.app.ui.components.CircularProgressIndicator
 import cc.wordview.app.ui.components.FormTextField
 import cc.wordview.app.ui.components.Icon
 import cc.wordview.app.ui.components.Space
+import kotlinx.coroutines.launch
 
 @Composable
 @Preview
@@ -69,7 +73,22 @@ fun Login(
 
     val context = LocalContext.current
 
-    Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+    val snackBarHostState = remember { SnackbarHostState() } // ✅ This line is essential!
+    val scope = rememberCoroutineScope()
+
+    // 🔁 Collect events from ViewModel
+    LaunchedEffect(Unit) {
+        viewModel.snackBarMessage.collect { message ->
+            // ✅ You can use `scope.launch` here, but it's optional
+            scope.launch {
+                snackBarHostState.showSnackbar(message)
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        snackbarHost = { SnackbarHost(snackBarHostState) }) { innerPadding ->
         Box(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Register.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Register.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -76,13 +77,12 @@ fun Register(
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
-    val snackBarHostState = remember { SnackbarHostState() } // ✅ This line is essential!
+    val snackBarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val message by viewModel.snackBarMessage.collectAsState(initial = "")
 
-    // 🔁 Collect events from ViewModel
-    if (message.isNotEmpty()) {
-        OneTimeEffect() {
+    LaunchedEffect(Unit) {
+        viewModel.snackBarMessage.collect {
             scope.launch {
                 snackBarHostState.showSnackbar(message)
             }

--- a/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Register.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Register.kt
@@ -46,7 +46,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import cc.wordview.app.ui.activities.auth.composables.FormValidation.*
+import cc.wordview.app.ui.activities.auth.composables.FormValidation.Email
+import cc.wordview.app.ui.activities.auth.composables.FormValidation.Password
 import cc.wordview.app.ui.activities.auth.viewmodel.register.RegisterViewModel
 import cc.wordview.app.ui.activities.home.HomeActivity
 import cc.wordview.app.ui.components.AuthForm

--- a/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Register.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/auth/composables/Register.kt
@@ -29,11 +29,15 @@ import androidx.compose.material.icons.filled.Password
 import androidx.compose.material3.Button
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,7 +58,9 @@ import cc.wordview.app.ui.components.AuthForm
 import cc.wordview.app.ui.components.CircularProgressIndicator
 import cc.wordview.app.ui.components.FormTextField
 import cc.wordview.app.ui.components.Icon
+import cc.wordview.app.ui.components.OneTimeEffect
 import cc.wordview.app.ui.components.Space
+import kotlinx.coroutines.launch
 
 @Composable
 @Preview
@@ -70,7 +76,22 @@ fun Register(
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
-    Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+    val snackBarHostState = remember { SnackbarHostState() } // ✅ This line is essential!
+    val scope = rememberCoroutineScope()
+    val message by viewModel.snackBarMessage.collectAsState(initial = "")
+
+    // 🔁 Collect events from ViewModel
+    if (message.isNotEmpty()) {
+        OneTimeEffect() {
+            scope.launch {
+                snackBarHostState.showSnackbar(message)
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        snackbarHost = { SnackbarHost(snackBarHostState) }) { innerPadding ->
         Box(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/cc/wordview/app/ui/activities/auth/viewmodel/register/RegisterViewModel.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/auth/viewmodel/register/RegisterViewModel.kt
@@ -21,9 +21,10 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cc.wordview.app.api.setStoredJwt
-import cc.wordview.app.extensions.showToast
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -35,8 +36,10 @@ class RegisterViewModel @Inject constructor(
     private val registerRepository: RegisterRepository
 ) : ViewModel() {
     private val _isLoading = MutableStateFlow(false)
-
     val isLoading = _isLoading.asStateFlow()
+
+    private var _snackBarMessage = MutableSharedFlow<String>()
+    val snackBarMessage = _snackBarMessage.asSharedFlow()
 
     fun register(
         username: String,
@@ -57,14 +60,18 @@ class RegisterViewModel @Inject constructor(
                 onRegisterCompleted.invoke()
             }
             onFail = { s: String, i: Int ->
-
                 Timber.e("Register failed \n\t message=$s, status=$i")
-                context.showToast("Register failed!")
-
+                emitMessage("Register failed!")
                 _isLoading.update { false }
             }
 
             register(username, email, password)
+        }
+    }
+
+    private fun emitMessage(msg: String) {
+        viewModelScope.launch {
+            _snackBarMessage.emit(msg)
         }
     }
 }


### PR DESCRIPTION
### Summary
- Replace toast message from loginViewModel to snackbar.
- Add Extension function for snackBar to common use.

### Attached Screenshot
![Screenshot 2025-04-19 202428](https://github.com/user-attachments/assets/1227d14e-365d-461a-9eb0-c7a5856d2d56)
![Screenshot 2025-04-19 202447](https://github.com/user-attachments/assets/53b084d4-b32e-4eee-9fef-9a1ab876ccd8)
![Screenshot 2025-04-19 202512](https://github.com/user-attachments/assets/d8cf2c2e-9e9d-4f53-94c5-60e408610ba0)

### Test Code
- Testing done using Login screen with wrong cred. 