### PR TITLE
Initialize TTS at the player setup

### DIFF
--- a/app/src/main/java/cc/wordview/app/ui/activities/lesson/composables/MeaningPresenter.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/lesson/composables/MeaningPresenter.kt
@@ -82,7 +82,7 @@ fun MeaningPresenter() {
         fadeIn.join()
 
         val tokenWord = currentWord.tokenWord
-        LessonViewModel.ttsSpeak(context, tokenWord.pronunciation ?: tokenWord.word, lang.locale)
+        LessonViewModel.ttsSpeak(tokenWord.pronunciation ?: tokenWord.word, lang.locale)
         delay(2000)
 
         val slideOut = launch {

--- a/app/src/main/java/cc/wordview/app/ui/activities/lesson/composables/Presenter.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/lesson/composables/Presenter.kt
@@ -102,7 +102,7 @@ fun Presenter() {
 
                     val tokenWord = currentWord.tokenWord
 
-                    LessonViewModel.ttsSpeak(context, tokenWord.pronunciation ?: tokenWord.word, Language.byTag(langTag).locale)
+                    LessonViewModel.ttsSpeak(tokenWord.pronunciation ?: tokenWord.word, Language.byTag(langTag).locale)
 
                     delay(3000.milliseconds)
                     visible = false

--- a/app/src/main/java/cc/wordview/app/ui/activities/lesson/viewmodel/LessonViewModel.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/lesson/viewmodel/LessonViewModel.kt
@@ -179,37 +179,24 @@ object LessonViewModel : ViewModel() {
         _mediaPlayer.value?.start()
     }
 
-    fun ttsSpeak(context: Context, word: String, locale: Locale) {
-        Timber.v("ttsSpeak: word=$word, locale=$locale")
+    fun initTts(context: Context) {
+        tts = TextToSpeech(context) {
+            Timber.v("initTts: ttsStatus=$it")
+        }
+    }
 
-        if (tts == null) {
-            tts = TextToSpeech(context) {
-                Timber.v("ttsSpeak: ttsStatus=$it")
+    fun ttsSpeak(word: String, locale: Locale) {
+        tts?.let { textToSpeech ->
+            Timber.v("ttsSpeak: word=$word, locale=$locale")
 
-                if (it == TextToSpeech.SUCCESS) {
-                    tts?.let { textToSpeech ->
-                        textToSpeech.language = locale
-                        textToSpeech.setSpeechRate(1.0f)
-                        textToSpeech.speak(
-                            word,
-                            TextToSpeech.QUEUE_ADD,
-                            null,
-                            null
-                        )
-                    }
-                }
-            }
-        } else {
-            tts?.let { textToSpeech ->
-                textToSpeech.language = locale
-                textToSpeech.setSpeechRate(1.0f)
-                textToSpeech.speak(
-                    word,
-                    TextToSpeech.QUEUE_ADD,
-                    null,
-                    null
-                )
-            }
+            textToSpeech.language = locale
+            textToSpeech.setSpeechRate(1.0f)
+            textToSpeech.speak(
+                word,
+                TextToSpeech.QUEUE_ADD,
+                null,
+                null
+            )
         }
     }
 }

--- a/app/src/main/java/cc/wordview/app/ui/activities/player/PlayerActivity.kt
+++ b/app/src/main/java/cc/wordview/app/ui/activities/player/PlayerActivity.kt
@@ -35,11 +35,11 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cc.wordview.app.SongViewModel
-import cc.wordview.app.api.getStoredJwt
 import cc.wordview.app.extensions.setOrientationSensorLandscape
 import cc.wordview.app.extractor.VideoStream
 import cc.wordview.app.misc.AppSettings
 import cc.wordview.app.ui.activities.WordViewActivity
+import cc.wordview.app.ui.activities.lesson.viewmodel.LessonViewModel
 import cc.wordview.app.ui.activities.player.composables.ErrorScreen
 import cc.wordview.app.ui.activities.player.composables.Player
 import cc.wordview.app.ui.activities.player.viewmodel.PlayerState
@@ -92,6 +92,10 @@ class PlayerActivity : WordViewActivity() {
                             viewModel.initAudio(videoStream.getStreamURL(), context)
                             viewModel.getLyrics(preferences, context, videoId, lang, videoStream)
                             viewModel.getKnownWords(context, lang)
+
+                            // we init the lesson tts here so that there is no delay
+                            // when the lesson actually starts.
+                            LessonViewModel.initTts(context)
                         } catch (e: ExtractionException) {
                             Timber.e(e)
                             viewModel.setErrorMessage(e.message.toString())


### PR DESCRIPTION
Closes #77 

Fixes the TTS taking too much time to initialize at the start of a lesson by creating the TTS object along with other player components